### PR TITLE
fix:Userモデルに関連付けの実装漏れがあったため修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,17 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   enum :role, { general: 0, admin: 1 }
+
+  # 投稿者として
+  has_many :brands
+  has_many :tea_products
+
+  # 承認者として
+  has_many :approved_brands,
+           class_name: "Brand",
+           foreign_key: :approved_by_id
+
+  has_many :approved_tea_products,
+           class_name: "TeaProduct",
+           foreign_key: :approved_by_id
 end


### PR DESCRIPTION
# 概要
UserモデルにBrandとTeaProductの関連付けが漏れていたため修正

# 実装内容
- 投稿者として
   has_many :brands
   has_many :tea_products
-   承認者として
  has_many :approved_brands,
           class_name: "Brand",
           foreign_key: :approved_by_id
  has_many :approved_tea_products,
           class_name: "TeaProduct",
           foreign_key: :approved_by_id

# 補足
辞典型アプリとして成立させるためにdependent: :destroyは無し。
db;reset実行。
コンソールでテストデータ確認。