### PR TITLE
fix:ActiveJobを:asyncに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,8 +50,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.active_job.queue_adapter = :async
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 概要
ActiveJob の queue_adapter を :async に変更。

## 目的
SolidQueue テーブル未作成による
ActiveStorage::AnalyzeJob enqueue エラー（500）を回避する目的。

## 補足
将来的にバックグラウンド処理を増やす場合は
SolidQueue または別のジョブキューへ再移行予定。