### PR TITLE
feat: 独自ドメイン対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
@@ -87,4 +87,6 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "kocha-zukan.com"
+  config.hosts << "www.kocha-zukan.com"
 end


### PR DESCRIPTION
### 概要
お名前.comにて独自ドメインを取得。
Renderへカスタムドメイン設定を行う。
Rails本番環境でのドメイン許可およびHTTPS強制設定を追加。

### 対応issue
closed #108
 
### 実施・実装内容
#### 1. 独自ドメイン取得
- 取得元：お名前.com
#### 2. DNS設定
 
| ホスト | TYPE | 値 |
| --- | --- | --- |
| www | CNAME | xxx.onrender.com |
|  @ | A | Render指定IP |

#### 3. Render側設定
- www.example.com 、example.comを追加
-  www.example.com を Primaryドメイン に設定
 
#### 4. Rails側設定
- production.rb
 ```
 config.hosts << "example.com"
config.hosts << "www.example.com"
config.force_ssl = true
 ```
 ### 目的
独自ドメインでの公開
ユーザー信頼性向上