### PR TITLE
hotfix: production.rbにホスト追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,4 +89,5 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.hosts << "kocha-zukan.com"
   config.hosts << "www.kocha-zukan.com"
+  config.hosts << "kocha-zukan.onrender.com"
 end


### PR DESCRIPTION
## 概要
独自ドメインがRenderでwaiting状態になっておりアプリにアクセスできないため、onrender.comもホストに追加。

### 実装内容
production.rbに以下を追記。
`config.hosts << "kocha-zukan.onrender.com"`