### PR TITLE
feat:　マイページに自分のレビュー一覧を追加

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -18,7 +18,7 @@ class MypagesController < ApplicationController
     @recent_reviews =
         current_user
         .reviews
-        .includes(:tea_product)
+        .includes(tea_product: { image_attachment: :blob })
         .order(created_at: :desc)
         .limit(3)
 
@@ -38,7 +38,7 @@ class MypagesController < ApplicationController
 
   def my_reviews
     @reviews = 
-      current_user.reviews.includes(:tea_product)
+      current_user.reviews.includes(tea_product: { image_attachment: :blob })
                           .order(created_at: :desc)
                           .page(params[:page])
                           .per(10)

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -2,13 +2,12 @@ class MypagesController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    # 共通の取得ロジックを使って全投稿を取得
+    # 全投稿を取得
     combined = fetch_all_posts
 
-    # 最新の3件をトップに表示
+    # 最新の3件
     @recent_posts = combined.first(3)
 
-    # お気に入り（ここは変更なし）
     @recent_favorite_tea_products =
       current_user
         .favorite_tea_products
@@ -16,27 +15,39 @@ class MypagesController < ApplicationController
         .order(created_at: :desc)
         .limit(3)
 
+    @recent_reviews =
+        current_user
+        .reviews
+        .includes(:tea_product)
+        .order(created_at: :desc)
+        .limit(3)
+
     @posts_count = combined.size
     @favorites_count = current_user.favorite_tea_products.count
+    @reviews_count = current_user.reviews.count
   end
 
-  # 自分の投稿一覧ページ
   def my_tea_products
     @posts = fetch_all_posts
   end
 
-  # お気に入り一覧ページ
   def favorites
     @favorite_tea_products =
       current_user.favorite_tea_products.includes(:image_attachment).order(created_at: :desc)
   end
 
+  def my_reviews
+    @reviews = 
+      current_user.reviews.includes(:tea_product)
+                          .order(created_at: :desc)
+                          .page(params[:page])
+                          .per(10)
+  end
+
   private
 
-  # 投稿データをまとめて取得・ソートする共通メソッド
+  # 投稿データをまとめて取得・ソート
   def fetch_all_posts
-    # 1. 申請中データ（ここでスコープを適用！）
-    # .active.latest_only を呼び出すことで、重複や古い申請を除外します
     submissions =
       current_user
         .tea_product_submissions
@@ -44,13 +55,11 @@ class MypagesController < ApplicationController
         .latest_only
         .includes(:image_attachment)
 
-    # 2. 公開済みの商品
     products =
       current_user
         .tea_products
         .includes(:image_attachment)
 
-    # 配列として結合して日付順に並べる
     (submissions.to_a + products.to_a).sort_by(&:created_at).reverse
   end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -37,7 +37,7 @@ class MypagesController < ApplicationController
   end
 
   def my_reviews
-    @reviews = 
+    @reviews =
       current_user.reviews.includes(tea_product: { image_attachment: :blob })
                           .order(created_at: :desc)
                           .page(params[:page])

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -40,7 +40,12 @@ class ReviewsController < ApplicationController
   def update
     if @review.update(review_params)
       flash[:notice] = "テイスティング記録を更新しました"
-      redirect_to tea_product_path(@tea_product)
+
+      if params[:from] == "mypage"
+        redirect_to my_reviews_mypage_path
+      else
+        redirect_to tea_product_path(@tea_product)
+      end
     else
       render :edit, status: :unprocessable_entity
     end
@@ -48,7 +53,12 @@ class ReviewsController < ApplicationController
 
   def destroy
     @review.destroy
-    redirect_to tea_product_path(@tea_product), notice: "テイスティング記録を削除しました"
+
+    if params[:from] == "mypage"
+      redirect_to my_reviews_mypage_path, notice: "削除しました"
+    else
+      redirect_to tea_product_path(@tea_product), notice: "削除しました"
+    end
   end
 
   private

--- a/app/javascript/controllers/review_modal_controller.js
+++ b/app/javascript/controllers/review_modal_controller.js
@@ -1,13 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
 
 export default class extends Controller {
-  // 背景クリックでモーダルを閉じる
   close(event) {
-    // クリックされたのが背景（このコントローラーが付与された要素自身）であるか確認
     if (event.target === this.element) {
-      const frame = document.getElementById("review_modal")
-      frame.src = ""       // 追加：リクエスト先をクリア
-      frame.innerHTML = "" // 中身を消去
+      const returnPath = this.element.dataset.returnPath
+      Turbo.visit(returnPath)
     }
   }
 

--- a/app/views/mypages/my_reviews.html.erb
+++ b/app/views/mypages/my_reviews.html.erb
@@ -42,11 +42,11 @@
               </div>
 
               <div class="flex items-center gap-3">
-                <%= link_to edit_tea_product_review_path(review.tea_product, review),
+                <%= link_to edit_tea_product_review_path(review.tea_product, review, from: "mypage"),
                     class: "flex-1 md:flex-none text-center px-4 py-2 bg-white border border-[#D6CEC5] text-[#365442] text-xs font-bold rounded hover:bg-[#FDFBF9] transition shadow-sm" do %>
                   編集する
                 <% end %>
-                <%= link_to tea_product_review_path(review.tea_product, review),
+                <%= link_to tea_product_review_path(review.tea_product, review, from: "mypage"),
                     data: { turbo_method: :delete, turbo_confirm: "この記録を完全に削除しますか？" },
                     class: "flex-1 md:flex-none text-center px-4 py-2 bg-white border border-red-100 text-red-400 text-xs font-bold rounded hover:bg-red-50 hover:text-red-500 transition shadow-sm" do %>
                   削除

--- a/app/views/mypages/my_reviews.html.erb
+++ b/app/views/mypages/my_reviews.html.erb
@@ -1,43 +1,126 @@
-<h1>自分のレビュー一覧</h1>
+<div class="min-h-screen bg-[#F1EFE9] py-8 md:py-12">
+  <div class="max-w-4xl mx-auto px-4 mb-16">
 
-<% if @reviews.any? %>
-  <div class="space-y-4">
-    <% @reviews.each do |review| %>
-      <div class="border p-4 rounded">
+    <div class="mb-10 border-b-2 border-[#B5A89A] pb-6">
+      <h1 class="text-2xl md:text-3xl font-serif font-bold text-[#365442] tracking-widest">
+        MY REVIEWS
+      </h1>
+      <p class="text-xs font-bold text-[#8C7B6C] mt-1 uppercase tracking-[0.2em]">
+        自分のレビュー一覧
+      </p>
+    </div>
 
-        <div class="text-sm text-gray-500">
-          <%= review.created_at.strftime("%Y.%m.%d") %>
-        </div>
+    <div class="mb-6">
+      <%= link_to mypage_path, class: "text-sm font-bold text-[#365442] hover:text-[#A75F29] inline-flex items-center gap-1" do %>
+        <span>←</span> <span>マイページに戻る</span>
+      <% end %>
+    </div>
 
-        <div class="font-bold">
-          <%= link_to review.tea_product.name,
-                tea_product_path(review.tea_product) %>
-        </div>
+    <% if @reviews.any? %>
+      <div class="space-y-8">
+        <% @reviews.each do |review| %>
+          <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl p-6 md:p-8 shadow-sm relative overflow-hidden group">
+            
+            <%# 左側のアクセントしおり %>
+            <div class="absolute left-0 top-0 w-1.5 h-full bg-[#8C7B6C] opacity-30 group-hover:opacity-100 transition-opacity duration-500"></div>
 
-        <div class="mt-2">
-          おすすめ度：
-          <%= render_stars(review.overall_rating) %>
-        </div>
+            <%# 上段：紅茶の情報と管理ボタン %>
+            <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6 pb-6 border-b border-[#F1EFE9]">
+              <div class="flex items-center gap-4">
+                <div class="w-16 h-16 bg-[#F1EFE9] border rounded-lg overflow-hidden flex-shrink-0 shadow-inner">
+                  <% if review.tea_product.image.attached? %>
+                    <%= image_tag review.tea_product.image, class: "w-full h-full object-cover" %>
+                  <% end %>
+                </div>
+                <div>
+                  <%= link_to review.tea_product.name, tea_product_path(review.tea_product),
+                      class: "text-lg font-bold text-[#365442] hover:text-[#A75F29] leading-tight" %>
+                  <div class="text-[11px] text-[#8C7B6C] font-mono mt-1">
+                    Reviewed on <%= review.created_at.strftime("%Y.%m.%d") %>
+                  </div>
+                </div>
+              </div>
 
-        <% if review.comment.present? %>
-          <p class="mt-2"><%= review.comment %></p>
+              <div class="flex items-center gap-3">
+                <%= link_to edit_tea_product_review_path(review.tea_product, review),
+                    class: "flex-1 md:flex-none text-center px-4 py-2 bg-white border border-[#D6CEC5] text-[#365442] text-xs font-bold rounded hover:bg-[#FDFBF9] transition shadow-sm" do %>
+                  編集する
+                <% end %>
+                <%= link_to tea_product_review_path(review.tea_product, review),
+                    data: { turbo_method: :delete, turbo_confirm: "この記録を完全に削除しますか？" },
+                    class: "flex-1 md:flex-none text-center px-4 py-2 bg-white border border-red-100 text-red-400 text-xs font-bold rounded hover:bg-red-50 hover:text-red-500 transition shadow-sm" do %>
+                  削除
+                <% end %>
+              </div>
+            </div>
+
+            <%# 中段：レーティング %>
+            <div class="mb-6">
+              <div class="flex items-baseline gap-2 mb-3">
+                <span class="text-[15px] font-bold text-[#433D3C] tracking-widest uppercase">おすすめ度</span>
+                <span class="text-[#B08F59] text-xl leading-none"><%= render_stars(review.overall_rating) %></span>
+              </div>
+
+              <div class="grid grid-cols-2 md:grid-cols-4 gap-y-4 gap-x-2 bg-[#F2F4F0]/50 rounded-xl p-4 border border-[#365442]/5">
+                <% [
+                  ["香り", review.aroma_rating, "控えめ", "強い"],
+                  ["渋み", review.bitterness_rating, "おだやか", "力強い"],
+                  ["濃厚さ", review.strength_rating, "すっきり", "コク"],
+                  ["甘み", review.sweetness_rating, "キレ", "余韻"]
+                ].each do |label, rating, low, high| %>
+                  <div class="flex flex-col items-center justify-center py-1">
+                    <span class="text-[14px] font-bold text-[#433D3C] mb-1"><%= label %></span>
+                    <span class="text-[#B08F59] text-sm leading-none"><%= render_stars(rating) %></span>
+                    <div class="flex justify-between w-full max-w-[80px] mt-1.5 opacity-60">
+                      <span class="text-[10px] text-[#433D3C] font-bold leading-none"><%= low %></span>
+                      <span class="text-[10px] text-[#433D3C] font-bold leading-none"><%= high %></span>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <%# --- 追加：おすすめの飲み方タグ --- %>
+            <% drinks = [] %>
+            <% drinks << "ストレート" if review.recommended_straight %>
+            <% drinks << "ミルク" if review.recommended_milk %>
+            <% drinks << "アイス" if review.recommended_iced %>
+
+            <% if drinks.any? %>
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mb-6">
+                <span class="text-[13px] font-bold text-[#433D3C] tracking-wider flex-shrink-0 uppercase">おすすめの飲み方</span>
+                <div class="flex flex-wrap gap-2">
+                  <% drinks.each do |drink| %>
+                    <span class="px-3 py-1 bg-white border border-[#D6CEC5] text-[#A75F29] text-[12px] font-bold rounded shadow-sm">
+                      # <%= drink %>
+                    </span>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+
+            <%# 下段：コメント %>
+            <% if review.comment.present? %>
+              <div class="relative bg-white/60 border-l-4 border-[#D6CEC5] p-5 rounded-r-xl">
+                <p class="text-[#433D3C] text-sm md:text-base leading-relaxed">
+                  <%= review.comment %>
+                </p>
+              </div>
+            <% end %>
+
+          </div>
         <% end %>
+      </div>
 
-        <div class="mt-2 flex gap-2 text-sm">
-          <%= link_to "編集",
-              edit_tea_product_review_path(review.tea_product, review) %>
+      <div class="mt-12">
+        <%= paginate @reviews %>
+      </div>
 
-          <%= link_to "削除",
-              tea_product_review_path(review.tea_product, review),
-              data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
-        </div>
-
+    <% else %>
+      <div class="bg-white border-2 border-dashed border-[#D6CEC5] rounded-2xl p-12 text-center">
+        <p class="text-[#8C7B6C] font-bold">レビューはまだありません</p>
       </div>
     <% end %>
+
   </div>
-
-  <%= paginate @reviews %>
-
-<% else %>
-  <p>レビューはまだありません</p>
-<% end %>
+</div>

--- a/app/views/mypages/my_reviews.html.erb
+++ b/app/views/mypages/my_reviews.html.erb
@@ -1,0 +1,43 @@
+<h1>自分のレビュー一覧</h1>
+
+<% if @reviews.any? %>
+  <div class="space-y-4">
+    <% @reviews.each do |review| %>
+      <div class="border p-4 rounded">
+
+        <div class="text-sm text-gray-500">
+          <%= review.created_at.strftime("%Y.%m.%d") %>
+        </div>
+
+        <div class="font-bold">
+          <%= link_to review.tea_product.name,
+                tea_product_path(review.tea_product) %>
+        </div>
+
+        <div class="mt-2">
+          おすすめ度：
+          <%= render_stars(review.overall_rating) %>
+        </div>
+
+        <% if review.comment.present? %>
+          <p class="mt-2"><%= review.comment %></p>
+        <% end %>
+
+        <div class="mt-2 flex gap-2 text-sm">
+          <%= link_to "編集",
+              edit_tea_product_review_path(review.tea_product, review) %>
+
+          <%= link_to "削除",
+              tea_product_review_path(review.tea_product, review),
+              data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+        </div>
+
+      </div>
+    <% end %>
+  </div>
+
+  <%= paginate @reviews %>
+
+<% else %>
+  <p>レビューはまだありません</p>
+<% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -109,5 +109,25 @@
         </div>
       <% end %>
     </div>
+    
+    <h2>最近のレビュー</h2>
+
+      <% if @recent_reviews.any? %>
+        <% @recent_reviews.each do |review| %>
+          <div>
+            <%= link_to review.tea_product.name,
+                  tea_product_path(review.tea_product) %>
+
+            <div>
+              <%= render_stars(review.overall_rating) %>
+            </div>
+          </div>
+        <% end %>
+
+        <%= link_to "すべて見る", my_reviews_mypage_path %>
+
+      <% else %>
+        <p>レビューはまだありません</p>
+      <% end %>
   </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -71,6 +71,51 @@
 
     <div class="flex justify-between items-center mt-12 mb-6">
       <h2 class="text-base font-bold text-[#365442] flex items-center gap-2">
+        <span class="w-1.5 h-4 bg-[#8C7B6C] rounded-full"></span>
+        自分のレビュー
+        <span class="text-xs bg-[#E9F0EC] text-[#365442] px-2 py-1 rounded">
+          <%= @reviews_count %>件
+        </span>
+      </h2>
+      <%= link_to "すべて見る →", my_reviews_mypage_path,
+          class: "text-sm font-bold text-[#365442] hover:text-[#A75F29]" %>
+    </div>
+
+    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
+      <% if @recent_reviews.any? %>
+        <ul class="divide-y-2 divide-[#F1EFE9]">
+          <% @recent_reviews.each do |review| %>
+            <li class="p-4 hover:bg-[#FDFBF9] transition">
+              <div class="flex items-center gap-4">
+                <div class="w-14 h-14 bg-[#F1EFE9] border rounded overflow-hidden flex-shrink-0">
+                  <% if review.tea_product.image.attached? %>
+                    <%= image_tag review.tea_product.image, class: "w-full h-full object-cover" %>
+                  <% end %>
+                </div>
+                <div class="flex-grow">
+                  <%= link_to review.tea_product.name, tea_product_path(review.tea_product),
+                      class: "font-bold text-[#365442] hover:text-[#A75F29] text-sm" %>
+                  <div class="flex items-center gap-2 mt-1">
+                    <div class="flex text-[#A75F29]">
+                      <%= render_stars(review.overall_rating) %>
+                    </div>
+                    <span class="text-[10px] text-[#8C7B6C]"><%= review.created_at.strftime("%Y.%m.%d") %></span>
+                  </div>
+                </div>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <div class="p-8 text-center text-[#8C7B6C] text-sm">
+          まだレビューを投稿していません。<br>
+          お気に入りの紅茶に感想を添えてみませんか？
+        </div>
+      <% end %>
+    </div>
+
+    <div class="flex justify-between items-center mt-12 mb-6">
+      <h2 class="text-base font-bold text-[#365442] flex items-center gap-2">
         <span class="w-1.5 h-4 bg-[#365442] rounded-full"></span>
         お気に入りの紅茶
         <span class="text-xs bg-[#E9F0EC] text-[#365442] px-2 py-1 rounded">
@@ -109,25 +154,5 @@
         </div>
       <% end %>
     </div>
-    
-    <h2>最近のレビュー</h2>
-
-      <% if @recent_reviews.any? %>
-        <% @recent_reviews.each do |review| %>
-          <div>
-            <%= link_to review.tea_product.name,
-                  tea_product_path(review.tea_product) %>
-
-            <div>
-              <%= render_stars(review.overall_rating) %>
-            </div>
-          </div>
-        <% end %>
-
-        <%= link_to "すべて見る", my_reviews_mypage_path %>
-
-      <% else %>
-        <p>レビューはまだありません</p>
-      <% end %>
   </div>
 </div>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -2,6 +2,7 @@
   <div
     data-controller="review-modal"
     data-action="click->review-modal#close"
+    data-return-path="<%= params[:from] == "mypage" ? my_reviews_mypage_path : tea_product_path(@tea_product) %>"
     class="fixed inset-0 flex items-center justify-center bg-[#1a2e22]/70 z-50 backdrop-blur-md p-4"
   >
     <div
@@ -32,6 +33,8 @@
 
           <%= form_with model: [@tea_product, review],
                 data: { turbo_frame: "_top" } do |f| %>
+
+            <%= hidden_field_tag :from, params[:from] %>
 
             <div class="space-y-10">
 
@@ -145,7 +148,10 @@
                 <%= f.submit "記録を保存する",
                       class: "w-full max-w-[240px] bg-[#365442] text-[#F9F7F2] py-3.5 rounded-xl font-serif font-bold tracking-widest shadow-lg hover:bg-[#2A4034] transition-all cursor-pointer border-b-4 border-[#1e3126] active:border-b-0 active:translate-y-1" %>
                 
-                <%= link_to "キャンセル", tea_product_path(@tea_product), data: { turbo_frame: "_top" }, class: "text-xs font-bold text-[#8C7B6C] hover:text-[#365442] transition-colors border-b border-[#D6CEC5] tracking-widest" %>
+                <%= link_to "キャンセル",
+                    (params[:from] == "mypage" ? my_reviews_mypage_path : tea_product_path(@tea_product)),
+                    data: { turbo_frame: "_top" },
+                    class: "text-xs font-bold text-[#8C7B6C] hover:text-[#365442] transition-colors border-b border-[#D6CEC5] tracking-widest" %>
               </div>
               
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   resource :mypage, only: %i[show] do
     get :my_tea_products
     get :favorites
+    get :my_reviews
   end
 
   resources :tea_products, only: %i[index show] do


### PR DESCRIPTION
## 概要
マイページにレビュー一覧機能を追加。編集や削除も行えるように実装。
あわせて、マイページからのレビュー操作後はマイページに戻る挙動に設定。

## 対応issue
closed #163
 
## 目的
- ユーザーが自身のレビューを一覧で管理できるようにするため。

## 実装内容
### 1. ルーティング
```
resource :mypage, only: %i[show] do
    get :my_reviews
end
```

### 2. コントローラー
- mypageコントローラー
レビュー用のアクションを追加。
```
def my_reviews 
  @reviews = 
     current_user.reviews 
                         .includes(tea_product: { image_attachment: :blob })
                         .order(created_at: :desc)
                         .page(params[:page])
                         .per(10)
end
```

- reviewコントローラー
updateアクション、 destroyアクションをマイページからの場合の分岐を追加。
```
    if params[:from] == "mypage"
```

### 3. ビュー
- マイページからの編集・削除リンク
`from: "mypage" `を付与して遷移元を識別。

- レビュー入力フォームモーダル
form_with に from パラメータを付与
```
<%= form_with model: [@tea_product, review], url: tea_product_review_path(@tea_product, review, from: params[:from]), data: { turbo_frame: "_top" } do |f| %>
```
戻り先を保持
```
data-return-path="<%= params[:from] == "mypage" ? my_reviews_mypage_path : tea_product_path(@tea_product) %>"
```


## 動作確認
マイページ
- [ ] レビュー一覧が表示される
- [ ] 編集 → マイページへ戻る
- [ ] 削除 → マイページへ戻る
- [ ] モーダルを閉じる → マイページへ戻る