### PR TITLE
feat: マイページにページネーション追加、デザインのブラッシュアップ

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -11,7 +11,7 @@ class MypagesController < ApplicationController
     @recent_favorite_tea_products =
       current_user
         .favorite_tea_products
-        .includes(:image_attachment)
+        .includes(:brand, :image_attachment)
         .order(created_at: :desc)
         .limit(3)
 

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -28,12 +28,19 @@ class MypagesController < ApplicationController
   end
 
   def my_tea_products
-    @posts = fetch_all_posts
+    all_posts = fetch_all_posts
+
+    @posts = Kaminari.paginate_array(all_posts)
+                     .page(params[:page])
+                     .per(10)
   end
 
   def favorites
     @favorite_tea_products =
-      current_user.favorite_tea_products.includes(:image_attachment).order(created_at: :desc)
+      current_user.favorite_tea_products.includes(:image_attachment)
+                                        .order(created_at: :desc)
+                                        .page(params[:page])
+                                        .per(10)
   end
 
   def my_reviews

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -37,7 +37,7 @@ class MypagesController < ApplicationController
 
   def favorites
     @favorite_tea_products =
-      current_user.favorite_tea_products.includes(:image_attachment)
+      current_user.favorite_tea_products.includes(:brand, :image_attachment)
                                         .order(created_at: :desc)
                                         .page(params[:page])
                                         .per(10)

--- a/app/views/mypages/favorites.html.erb
+++ b/app/views/mypages/favorites.html.erb
@@ -1,76 +1,100 @@
 <div class="min-h-screen bg-[#F1EFE9] py-8 md:py-12">
   <div class="max-w-4xl mx-auto px-4 mb-16">
 
+    <%# --- ヘッダー --- %>
     <div class="mb-10 border-b-2 border-[#B5A89A] pb-6">
       <h1 class="text-2xl md:text-3xl font-serif font-bold text-[#365442] tracking-widest">
         FAVORITE TEAS
       </h1>
       <p class="text-xs font-bold text-[#8C7B6C] mt-1 uppercase tracking-[0.2em]">
-        お気に入り一覧
+        お気に入りコレクション
       </p>
     </div>
 
-    <div class="mb-6">
+    <div class="mb-8">
       <%= link_to mypage_path, class: "text-sm font-bold text-[#365442] hover:text-[#A75F29] inline-flex items-center gap-1" do %>
         <span>←</span> <span>マイページに戻る</span>
       <% end %>
     </div>
 
-    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
-      <table class="w-full text-sm border-collapse table-auto">
+    <%# --- カードリスト --- %>
+    <% if @favorite_tea_products.any? %>
+      <div class="space-y-6">
+        <% @favorite_tea_products.each do |tea| %>
+          <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl p-5 md:p-6 shadow-sm relative overflow-hidden group hover:shadow-md transition-all duration-300">
+            
+            <%# 左側のアクセントしおり（お気に入りテーマの深緑） %>
+            <div class="absolute left-0 top-0 w-1.5 h-full bg-[#365442]/80 opacity-30 group-hover:opacity-100 transition-opacity"></div>
 
-        <thead class="bg-[#F9F7F2] border-b-2 border-[#D6CEC5]">
-          <tr>
-            <th class="p-4 w-20 md:w-32 text-center font-bold text-[#365442]">
-              画像
-            </th>
-        
-            <th class="p-4 text-left font-bold text-[#365442]">
-              紅茶名
-            </th>
-        
-            <th class="p-4 w-px text-center font-bold text-[#365442] whitespace-nowrap">
-              お気に入り
-            </th>
-          </tr>
-        </thead>
+            <%# 右上のお気に入りボタン %>
+            <div class="absolute top-4 right-4 z-10 scale-90 md:scale-100">
+              <%= turbo_frame_tag "favorite_button_#{tea.id}" do %>
+                <%= render "favorites/button", tea_product: tea %>
+              <% end %>
+            </div>
 
-        <tbody class="divide-y-2 divide-[#F1EFE9]">
-          <% @favorite_tea_products.each do |tea| %>
-            <tr class="hover:bg-[#FDFBF9]">
-          
-              <%# --- 画像エリア --- %>
-              <td class="p-4">
-                <div class="w-12 h-12 md:w-20 md:h-20 mx-auto bg-[#F1EFE9] border overflow-hidden rounded">
-                  <% if tea.image.attached? %>
-                    <%= image_tag tea.image, class: "w-full h-full object-cover" %>
+            <div class="flex items-center gap-5 md:gap-8">
+              <%# 画像エリア %>
+              <div class="w-20 h-20 md:w-28 md:h-28 bg-[#F1EFE9] border border-[#D6CEC5]/50 rounded-xl overflow-hidden flex-shrink-0 shadow-inner">
+                <% if tea.image.attached? %>
+                  <%= image_tag tea.image, class: "w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" %>
+                <% else %>
+                  <div class="w-full h-full flex items-center justify-center text-[#D6CEC5] bg-[#FDFBF9]">
+                    <span class="text-[10px] font-serif opacity-60">NO IMAGE</span>
+                  </div>
+                <% end %>
+              </div>
+
+              <%# 情報エリア %>
+              <div class="flex-1 pr-8"> <%# ボタンと被らないよう右に余白 %>
+                <div class="mb-1">
+                  <% if tea.brand.present? %>
+                    <span class="text-[10px] md:text-xs font-bold text-[#A75F29] tracking-widest uppercase opacity-80">
+                      <%= tea.brand.name_ja || tea.brand.name_en %>
+                    </span>
+                  <% else %>
+                    <span class="text-[10px] font-bold text-[#8C7B6C] tracking-widest uppercase opacity-60">Tea Archive</span>
                   <% end %>
                 </div>
-              </td>
 
-              <%# --- 名前エリア --- %>
-              <td class="p-4">
-                <%= link_to tea_product_path(tea),
-                    class: "font-bold text-[#365442] hover:text-[#A75F29] leading-tight block break-words" do %>
-                  <%= tea.name %>
-                <% end %>
-              </td>
-
-              <%# --- ボタンエリア --- %>
-              <td class="p-4 text-center whitespace-nowrap">
-                <div class="inline-block scale-90 sm:scale-100">
-                  <%= render "favorites/button", tea_product: tea %>
+                <h3 class="text-base md:text-xl font-bold text-[#365442] leading-tight mb-3">
+                  <%= link_to tea.name, tea_product_path(tea), class: "hover:text-[#A75F29] transition-colors" %>
+                </h3>
+                
+                <div class="flex items-center gap-4">
+                  <div class="text-[10px] md:text-[11px] text-[#8C7B6C] font-mono tracking-wider flex items-center gap-1.5">
+                    <span class="w-1 h-1 rounded-full bg-[#D6CEC5]"></span>
+                    ADDED: <%= tea.created_at.strftime("%Y.%m.%d") %>
+                  </div>
+                  
+                  <%# レビュー済みかどうかのステータス（あれば便利） %>
+                  <% if current_user.reviews.exists?(tea_product_id: tea.id) %>
+                    <span class="text-[10px] font-bold px-1.5 py-0.5 bg-[#F2F4F0] text-[#365442] border border-[#365442]/10 rounded">レビュー済</span>
+                  <% end %>
                 </div>
-              </td>
+              </div>
 
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+              <%# 右端の矢印（PCのみ） %>
+              <div class="hidden md:block text-[#D6CEC5] group-hover:text-[#365442] transition-colors pr-2">
+                <span class="text-2xl font-serif">→</span>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
 
-    <div class="mt-12">
-      <%= paginate @favorite_tea_products %>
-    </div>
+      <div class="mt-12 flex justify-center">
+        <%= paginate @favorite_tea_products %>
+      </div>
+
+    <% else %>
+      <%# 空の状態のデザイン %>
+      <div class="bg-white/50 border-2 border-dashed border-[#D6CEC5] rounded-2xl p-16 text-center">
+        <p class="text-[#8C7B6C] font-bold tracking-widest mb-4">お気に入りの紅茶はまだありません</p>
+        <%= link_to "紅茶一覧を見る", tea_products_path, 
+            class: "inline-block text-sm font-bold text-[#365442] border-b border-[#365442] pb-0.5" %>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/app/views/mypages/favorites.html.erb
+++ b/app/views/mypages/favorites.html.erb
@@ -17,22 +17,18 @@
     </div>
 
     <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
-      <%# table-auto に戻すことで、中身のサイズに応じて列幅が柔軟に調整されるようになります %>
       <table class="w-full text-sm border-collapse table-auto">
 
         <thead class="bg-[#F9F7F2] border-b-2 border-[#D6CEC5]">
           <tr>
-            <%# 画像列：スマホでは小さく、PCでは固定幅 %>
             <th class="p-4 w-20 md:w-32 text-center font-bold text-[#365442]">
               画像
             </th>
         
-            <%# 名前列：幅を指定せず、余ったスペースをすべて使う %>
             <th class="p-4 text-left font-bold text-[#365442]">
               紅茶名
             </th>
         
-            <%# ボタン列：w-px（最小幅）を指定し、中身のサイズ（white-space: nowrap）に合わせる %>
             <th class="p-4 w-px text-center font-bold text-[#365442] whitespace-nowrap">
               お気に入り
             </th>
@@ -61,7 +57,6 @@
               </td>
 
               <%# --- ボタンエリア --- %>
-              <%# whitespace-nowrap を入れることで、タブレットサイズでも「解除」が絶対に縦に並びません %>
               <td class="p-4 text-center whitespace-nowrap">
                 <div class="inline-block scale-90 sm:scale-100">
                   <%= render "favorites/button", tea_product: tea %>
@@ -72,6 +67,10 @@
           <% end %>
         </tbody>
       </table>
+    </div>
+
+    <div class="mt-12">
+      <%= paginate @favorite_tea_products %>
     </div>
   </div>
 </div>

--- a/app/views/mypages/my_tea_products.html.erb
+++ b/app/views/mypages/my_tea_products.html.erb
@@ -100,6 +100,10 @@
       </div>
     </div>
 
+    <div class="mt-12">
+      <%= paginate @posts %>
+    </div>
+
     <div class="mt-10 text-center">
       <%= link_to "新規投稿を作成する", new_tea_product_submission_path,
           class: "inline-block border-2 border-[#365442] text-[#365442]

--- a/app/views/mypages/my_tea_products.html.erb
+++ b/app/views/mypages/my_tea_products.html.erb
@@ -1,114 +1,131 @@
 <div class="min-h-screen bg-[#F1EFE9] py-8 md:py-12">
   <div class="max-w-4xl mx-auto px-4 mb-16">
 
+    <%# --- ヘッダー --- %>
     <div class="mb-10 border-b-2 border-[#B5A89A] pb-6">
       <h1 class="text-2xl md:text-3xl font-serif font-bold text-[#365442] tracking-widest">
         MY TEA POSTS
       </h1>
       <p class="text-xs font-bold text-[#8C7B6C] mt-1 uppercase tracking-[0.2em]">
-        自分の投稿一覧
+        自分の投稿一覧・管理
       </p>
     </div>
 
-    <div class="mb-6">
-      <%= link_to "← マイページに戻る", mypage_path,
-          class: "text-sm font-bold text-[#365442] hover:text-[#A75F29]" %>
+    <%# ナビゲーション行：マイページへ戻る ＆ 新規投稿作成 %>
+    <div class="mb-8 flex items-center justify-between gap-4">
+      <%= link_to mypage_path, class: "text-sm font-bold text-[#365442] hover:text-[#A75F29] inline-flex items-center gap-1" do %>
+        <span>←</span> <span>マイページに戻る</span>
+      <% end %>
+
+      <%= link_to new_tea_product_submission_path,
+          class: "bg-white border-2 border-[#365442] text-[#365442] text-[13px] md:text-[13px] font-bold px-5 py-2.5 rounded-lg shadow-sm hover:bg-[#365442] hover:text-white transition-all tracking-widest" do %>
+        ＋ 新規投稿を作成
+      <% end %>
     </div>
 
-    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm min-w-[650px] border-collapse">
+    <%# --- カードリスト --- %>
+    <div class="space-y-6">
+      <% if @posts.any? %>
+        <% @posts.each do |tea| %>
+          <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl p-5 md:p-6 shadow-sm relative overflow-hidden group">
+            
+            <%# 左側のアクセントしおり %>
+            <div class="absolute left-0 top-0 w-1.5 h-full bg-[#A75F29]/80 opacity-40 group-hover:opacity-100 transition-opacity"></div>
 
-          <thead class="bg-[#F9F7F2] border-b-2 border-[#D6CEC5]">
-            <tr>
-              <th class="p-4 w-32 text-center font-bold text-[#365442] tracking-wider">画像</th>
-              <th class="p-4 text-left font-bold text-[#365442] tracking-wider">紅茶名 / 商品詳細</th>
-              <th class="p-4 w-32 text-center font-bold text-[#365442] tracking-wider">ステータス</th>
-              <th class="p-4 w-32 text-center font-bold text-[#365442] tracking-wider">操作</th>
-            </tr>
-          </thead>
-
-          <tbody class="divide-y-2 divide-[#F1EFE9]">
-            <% @posts.each do |tea| %>
-              <tr class="hover:bg-[#FDFBF9] transition-colors">
-                <td class="p-4 text-center">
-                  <div class="w-20 h-20 mx-auto bg-[#F1EFE9] border-2 border-[#D6CEC5] flex items-center justify-center overflow-hidden rounded shadow-sm">
-                    <% if tea.image.attached? %>
-                      <%= image_tag tea.image, class: "w-full h-full object-cover" %>
-                    <% else %>
-                      <span class="text-[10px] font-bold text-[#B5A89A] uppercase">No Image</span>
-                    <% end %>
-                  </div>
-                </td>
-
-                <td class="p-4">
-                  <% if tea.is_a?(TeaProduct) %>
-                    <%= link_to tea_product_path(tea), class: "group" do %>
-                      <span class="text-base font-bold text-[#365442] group-hover:text-[#A75F29] group-hover:underline transition decoration-2">
-                        <%= tea.name %>
-                      </span>
-                    <% end %>
+            <div class="flex flex-col md:flex-row md:items-center gap-5">
+              
+              <%# --- 左セクション：画像 ＋ 基本情報 --- %>
+              <div class="flex flex-1 items-center gap-5">
+                <%# 画像エリア %>
+                <div class="w-16 h-16 md:w-24 md:h-24 bg-[#F1EFE9] border border-[#D6CEC5]/50 rounded-xl overflow-hidden flex-shrink-0 shadow-inner">
+                  <% if tea.image.attached? %>
+                    <%= image_tag tea.image, class: "w-full h-full object-cover transition-transform group-hover:scale-105" %>
                   <% else %>
-                    <%= link_to edit_tea_product_submission_path(tea), class: "group" do %>
-                      <span class="text-base font-bold text-[#365442] group-hover:text-[#A75F29]">
-                        <%= tea.name %>
-                      </span>
-                    <% end %>
-                    <div class="text-[10px] text-[#8C7B6C] mt-1 font-semibold uppercase tracking-tighter">
-                      Created at: <%= tea.created_at.strftime("%Y.%m.%d") %>
+                    <div class="w-full h-full flex items-center justify-center text-[#B5A89A] bg-[#FDFBF9]">
+                      <span class="text-[8px] font-bold uppercase">No Image</span>
                     </div>
                   <% end %>
-                </td>
+                </div>
 
-                <td class="p-4 text-center">
-                  <% if tea.is_a?(TeaProductSubmission) %>
-                    <% 
-                      status_styles = case tea.status
-                        when "draft" then "bg-[#EBE5DE] text-[#5D554E] border-[#B5A89A]"
-                        when "pending" then "bg-[#FFF9F2] text-[#A75F29] border-[#E0943D]"
-                        when "published" then "bg-[#E9F0EC] text-[#365442] border-[#365442]"
-                        when "rejected" then "bg-red-50 text-red-700 border-red-200"
-                        else "bg-gray-100 text-gray-600 border-gray-300"
-                      end
-                    %>
-                    <span class="px-3 py-1 rounded border font-bold text-[11px] tracking-wider inline-block <%= status_styles %>">
-                      <%= tea.status_i18n %>
-                    </span>
-                  <% else %>
-                    <%# 公開済みのTeaProduct用表示 %>
-                    <span class="px-3 py-1 rounded border font-bold text-[11px] tracking-wider inline-block bg-[#E9F0EC] text-[#365442] border-[#365442]">
-                      公開済み
-                    </span>
+                <%# テキストエリア %>
+                <div class="min-w-0">
+                  <% if tea.is_a?(TeaProduct) && tea.brand.present? %>
+                    <div class="text-[10px] font-bold text-[#A75F29] tracking-widest uppercase opacity-80 mb-0.5">
+                      <%= tea.brand.name_ja || tea.brand.name_en %>
+                    </div>
                   <% end %>
-                </td>
 
-                <td class="p-4 text-center">
+                  <h3 class="text-base md:text-lg font-bold text-[#365442] leading-tight truncate">
+                    <% if tea.is_a?(TeaProduct) %>
+                      <%= link_to tea.name, tea_product_path(tea), class: "hover:text-[#A75F29] transition-colors" %>
+                    <% else %>
+                      <%= link_to tea.name, edit_tea_product_submission_path(tea), class: "hover:text-[#A75F29] transition-colors" %>
+                    <% end %>
+                  </h3>
+
+                  <div class="text-[11px] text-[#8C7B6C] font-mono mt-1">
+                    Created at: <%= tea.created_at.strftime("%Y.%m.%d") %>
+                  </div>
+                </div>
+              </div>
+
+              <%# --- 右セクション：ステータス ＆ アクション --- %>
+              <div class="flex items-center justify-between md:justify-end gap-3 pt-4 md:pt-0 border-t md:border-t-0 border-[#F1EFE9]">
+                
+                <%# ステータスバッジ %>
+                <% if tea.is_a?(TeaProductSubmission) %>
+                  <% 
+                    status_styles = case tea.status
+                      when "draft" then "bg-[#EBE5DE] text-[#5D554E] border-[#B5A89A]"
+                      when "pending" then "bg-[#FFF9F2] text-[#A75F29] border-[#E0943D]"
+                      when "published" then "bg-[#E9F0EC] text-[#365442] border-[#365442]"
+                      when "rejected" then "bg-red-50 text-red-700 border-red-200"
+                      else "bg-gray-100 text-gray-600 border-gray-300"
+                    end
+                  %>
+                  <span class="px-2.5 py-1 rounded border font-bold text-[11px] md:text-[11px] tracking-wider uppercase whitespace-nowrap <%= status_styles %>">
+                    <%= tea.status_i18n %>
+                  </span>
+                <% else %>
+                  <span class="px-2.5 py-1 rounded border border-[#365442] bg-[#E9F0EC] text-[#365442] font-bold text-[11px] md:text-[11px] tracking-wider uppercase whitespace-nowrap">
+                    公開済み
+                  </span>
+                <% end %>
+
+                <%# アクションボタン %>
+                <div class="flex items-center min-w-[90px] justify-end">
                   <% if tea.is_a?(TeaProductSubmission) && (tea.draft? || tea.rejected?) %>
+                    <%# 編集ボタン（緑背景・白文字） %>
                     <%= link_to edit_tea_product_submission_path(tea),
-                        class: "inline-block bg-[#365442] hover:bg-[#2A4034] text-[#F9F7F2] text-xs font-bold px-4 py-2 rounded shadow transition tracking-widest" do %>
-                      編集
+                        class: "px-5 py-2 bg-[#365442] text-white text-[12px] tracking-normal rounded shadow-sm hover:bg-[#2A4034] transition whitespace-nowrap" do %>
+                      編集する
                     <% end %>
                   <% else %>
-                    <span class="text-[#B5A89A] text-xs font-serif italic">- Locked -</span>
+                    <%# 編集不可（ロック）表示 %>
+                    <div class="flex flex-col items-end opacity-60">
+                      <div class="flex items-center gap-1 text-[#5D554E] mb-0.5">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                          <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />
+                        </svg>
+                        <span class="text-[12px] font-bold">編集不可　</span>
+                      </div>
+                    </div>
                   <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
+                </div>
+              </div>
 
-        </table>
-      </div>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="bg-white border-2 border-dashed border-[#D6CEC5] rounded-2xl p-16 text-center">
+          <p class="text-[#8C7B6C] font-bold tracking-widest">投稿した紅茶はまだありません</p>
+        </div>
+      <% end %>
     </div>
 
-    <div class="mt-12">
+    <div class="mt-12 flex justify-center">
       <%= paginate @posts %>
-    </div>
-
-    <div class="mt-10 text-center">
-      <%= link_to "新規投稿を作成する", new_tea_product_submission_path,
-          class: "inline-block border-2 border-[#365442] text-[#365442]
-                 hover:bg-[#365442] hover:text-white
-                 font-bold px-8 py-3 rounded-lg transition-all duration-300 tracking-widest" %>
     </div>
 
   </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,6 +1,7 @@
 <div class="min-h-screen bg-[#F1EFE9] py-8 md:py-12">
   <div class="max-w-4xl mx-auto px-4 mb-16">
 
+    <%# --- ヘッダー --- %>
     <div class="mb-10 border-b-2 border-[#B5A89A] pb-6">
       <h1 class="text-2xl md:text-3xl font-serif font-bold text-[#365442] tracking-widest">
         MY ARCHIVE
@@ -10,149 +11,171 @@
       </p>
     </div>
 
-    <div class="flex justify-between items-center mb-6">
-      <h2 class="text-base font-bold text-[#365442] flex items-center gap-2">
+    <%# --- 1. 自分の投稿 --- %>
+    <div class="flex justify-between items-end mb-4">
+      <h2 class="text-[17px] font-bold text-[#365442] flex items-center gap-2">
         <span class="w-1.5 h-4 bg-[#A75F29] rounded-full"></span>
         自分の投稿
-        <span class="text-xs bg-[#EBE5DE] text-[#5D554E] px-2 py-1 rounded">
+        <span class="text-xs bg-[#A75F29]/10 text-[#A75F29] px-2 py-1 rounded">
           <%= @posts_count %>件
         </span>
       </h2>
-      <%= link_to "すべて見る →", my_tea_products_mypage_path,
-          class: "text-sm font-bold text-[#365442] hover:text-[#A75F29]" %>
+      <%= link_to my_tea_products_mypage_path, class: "text-[13px] font-bold text-[#A75F29] hover:underline tracking-wider" do %>
+        すべて見る <span class="text-xs">→</span>
+      <% end %>
     </div>
 
-    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
+    <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl shadow-sm overflow-hidden mb-6">
       <% if @recent_posts.any? %>
-        <table class="w-full text-sm border-collapse">
-          <tbody class="divide-y-2 divide-[#F1EFE9]">
-            <% @recent_posts.each do |tea| %>
-              <tr class="hover:bg-[#FDFBF9]">
-                <td class="p-4 w-24 text-center">
-                  <div class="w-16 h-16 mx-auto bg-[#F1EFE9] border overflow-hidden rounded">
-                    <% if tea.image.attached? %>
-                      <%= image_tag tea.image, class: "w-full h-full object-cover" %>
-                    <% end %>
-                  </div>
-                </td>
-                <td class="p-4">
-                  <%# モデルによってリンク先を切り替え %>
-                  <% target_path = tea.is_a?(TeaProduct) ? tea_product_path(tea) : edit_tea_product_submission_path(tea) %>
-                  
-                  <%= link_to target_path, class: "font-bold text-[#365442] hover:text-[#A75F29]" do %>
-                    <%= tea.name %>
+        <div class="divide-y divide-[#F1EFE9]">
+          <% @recent_posts.each do |tea| %>
+            <div class="group relative flex items-center p-4 hover:bg-[#FDFBF9] transition-colors">
+              <%# 薄いアクセントライン %>
+              <div class="absolute left-0 top-0 w-1 h-full bg-[#A75F29] opacity-0 group-hover:opacity-40 transition-opacity"></div>
+              
+              <div class="w-14 h-14 bg-[#F1EFE9] border border-[#D6CEC5]/50 rounded-lg overflow-hidden flex-shrink-0">
+                <% if tea.image.attached? %>
+                  <%= image_tag tea.image, class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" %>
+                <% end %>
+              </div>
+              
+              <div class="ml-4 flex-grow">
+                <% target_path = tea.is_a?(TeaProduct) ? tea_product_path(tea) : edit_tea_product_submission_path(tea) %>
+                <%= link_to tea.name, target_path, class: "block font-bold text-[#365442] hover:text-[#A75F29] text-base leading-tight mb-1" %>
+                <div class="flex items-center gap-3">
+                  <span class="text-[11px] text-[#8C7B6C] font-mono"><%= tea.created_at.strftime("%Y.%m.%d") %></span>
+                  <% if tea.is_a?(TeaProductSubmission) %>
+                    <span class="text-[10px] px-1.5 py-0.5 bg-[#FFF9F2] text-[#A75F29] border border-[#E0943D]/30 rounded font-bold">
+                      <%= tea.status_i18n %>
+                    </span>
+                  <% else %>
+                    <span class="text-[10px] px-1.5 py-0.5 bg-[#E9F0EC] text-[#365442] border border-[#365442]/20 rounded font-bold">公開済</span>
                   <% end %>
-
-                  <div class="text-xs text-[#8C7B6C]">
-                    <%= tea.created_at.strftime("%Y.%m.%d") %>
-                    <% if tea.is_a?(TeaProductSubmission) %>
-                      <span class="ml-2 text-[10px] px-1 bg-[#FFF9F2] text-[#A75F29] border border-[#E0943D] rounded">作業中</span>
-                    <% end %>
-                  </div>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+                </div>
+              </div>
+              <div class="text-[#D6CEC5] group-hover:text-[#365442] transition-colors pr-2">
+                <span class="text-lg font-serif">→</span>
+              </div>
+            </div>
+          <% end %>
+        </div>
       <% else %>
-        <div class="p-8 text-center text-[#8C7B6C] text-sm">
-          まだ投稿がありません。<br>
-          下のボタンから最初の紅茶を登録してみましょう。
+        <div class="p-10 text-center text-[#8C7B6C] text-sm font-medium italic">
+          No posts.
         </div>
       <% end %>
     </div>
 
-    <div class="mt-6 text-center">
-      <%= link_to "新規投稿を作成する", new_tea_product_submission_path,
-          class: "inline-block border-2 border-[#365442] text-[#365442]
-                 hover:bg-[#365442] hover:text-white
-                 font-bold px-8 py-3 rounded-lg transition-all duration-300 tracking-widest" %>
+    <%# 前回の修正を反映：白背景×緑文字 %>
+    <div class="mb-12 text-right">
+      <%= link_to new_tea_product_submission_path,
+          class: "inline-block bg-white border-2 border-[#365442] text-[#365442]
+                  hover:bg-[#365442] hover:text-white
+                  font-bold px-6 py-2.5 rounded-lg transition-all duration-300 tracking-widest text-sm" do %>
+        ＋ 新規投稿を作成する
+      <% end %>
     </div>
 
-    <div class="flex justify-between items-center mt-12 mb-6">
-      <h2 class="text-base font-bold text-[#365442] flex items-center gap-2">
+    <%# --- 2. 自分のレビュー --- %>
+    <div class="flex justify-between items-end mb-4 mt-12">
+      <h2 class="text-[17px] font-bold text-[#365442] flex items-center gap-2">
         <span class="w-1.5 h-4 bg-[#8C7B6C] rounded-full"></span>
         自分のレビュー
-        <span class="text-xs bg-[#E9F0EC] text-[#365442] px-2 py-1 rounded">
+        <span class="text-xs bg-[#EBE5DE] text-[#5D554E] px-2 py-1 rounded">
           <%= @reviews_count %>件
         </span>
       </h2>
-      <%= link_to "すべて見る →", my_reviews_mypage_path,
-          class: "text-sm font-bold text-[#365442] hover:text-[#A75F29]" %>
+      <%= link_to my_reviews_mypage_path, class: "text-[13px] font-bold text-[#A75F29] hover:underline tracking-wider" do %>
+        すべて見る <span class="text-xs">→</span>
+      <% end %>
     </div>
 
-    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg overflow-hidden">
+    <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl shadow-sm overflow-hidden mb-12">
       <% if @recent_reviews.any? %>
-        <ul class="divide-y-2 divide-[#F1EFE9]">
+        <div class="divide-y divide-[#F1EFE9]">
           <% @recent_reviews.each do |review| %>
-            <li class="p-4 hover:bg-[#FDFBF9] transition">
-              <div class="flex items-center gap-4">
-                <div class="w-14 h-14 bg-[#F1EFE9] border rounded overflow-hidden flex-shrink-0">
-                  <% if review.tea_product.image.attached? %>
-                    <%= image_tag review.tea_product.image, class: "w-full h-full object-cover" %>
-                  <% end %>
-                </div>
-                <div class="flex-grow">
-                  <%= link_to review.tea_product.name, tea_product_path(review.tea_product),
-                      class: "font-bold text-[#365442] hover:text-[#A75F29] text-sm" %>
-                  <div class="flex items-center gap-2 mt-1">
-                    <div class="flex text-[#A75F29]">
-                      <%= render_stars(review.overall_rating) %>
-                    </div>
-                    <span class="text-[10px] text-[#8C7B6C]"><%= review.created_at.strftime("%Y.%m.%d") %></span>
+            <div class="group relative flex items-center p-4 hover:bg-[#FDFBF9] transition-colors">
+              <div class="absolute left-0 top-0 w-1 h-full bg-[#8C7B6C] opacity-0 group-hover:opacity-40 transition-opacity"></div>
+              
+              <div class="w-14 h-14 bg-[#F1EFE9] border border-[#D6CEC5]/50 rounded-lg overflow-hidden flex-shrink-0">
+                <% if review.tea_product.image.attached? %>
+                  <%= image_tag review.tea_product.image, class: "w-full h-full object-cover group-hover:scale-105 transition-transform" %>
+                <% end %>
+              </div>
+              
+              <div class="ml-4 flex-grow">
+                <%= link_to review.tea_product.name, tea_product_path(review.tea_product),
+                    class: "block font-bold text-[#365442] hover:text-[#A75F29] text-base leading-tight mb-1" %>
+                <div class="flex items-center gap-3">
+                  <div class="flex text-[#A75F29] text-[11px]">
+                    <%= render_stars(review.overall_rating) %>
                   </div>
+                  <span class="text-[11px] text-[#8C7B6C] font-mono"><%= review.created_at.strftime("%Y.%m.%d") %></span>
                 </div>
               </div>
-            </li>
+              <div class="text-[#D6CEC5] group-hover:text-[#365442] transition-colors pr-2">
+                <span class="text-lg font-serif">→</span>
+              </div>
+            </div>
           <% end %>
-        </ul>
+        </div>
       <% else %>
-        <div class="p-8 text-center text-[#8C7B6C] text-sm">
-          まだレビューを投稿していません。<br>
-          お気に入りの紅茶に感想を添えてみませんか？
+        <div class="p-10 text-center text-[#8C7B6C] text-sm font-medium italic">
+          No reviews recorded.
         </div>
       <% end %>
     </div>
 
-    <div class="flex justify-between items-center mt-12 mb-6">
-      <h2 class="text-base font-bold text-[#365442] flex items-center gap-2">
+    <%# --- 3. お気に入りの紅茶 --- %>
+    <div class="flex justify-between items-end mb-4 mt-12">
+      <h2 class="text-[17px] font-bold text-[#365442] flex items-center gap-2">
         <span class="w-1.5 h-4 bg-[#365442] rounded-full"></span>
         お気に入りの紅茶
         <span class="text-xs bg-[#E9F0EC] text-[#365442] px-2 py-1 rounded">
           <%= @favorites_count %>件
         </span>
       </h2>
-      <%= link_to "すべて見る →", favorites_mypage_path,
-          class: "text-sm font-bold text-[#365442] hover:text-[#A75F29]" %>
+      <%= link_to favorites_mypage_path, class: "text-[13px] font-bold text-[#A75F29] hover:underline tracking-wider" do %>
+        すべて見る <span class="text-xs">→</span>
+      <% end %>
     </div>
 
-    <div class="bg-white border-2 border-[#D6CEC5] rounded-lg shadow-lg p-4">
+    <div class="bg-white border-2 border-[#D6CEC5] rounded-2xl shadow-sm overflow-hidden">
       <% if @recent_favorite_tea_products.any? %>
-        <ul class="space-y-3">
+        <div class="divide-y divide-[#F1EFE9]">
           <% @recent_favorite_tea_products.each do |tea| %>
-            <li class="flex items-center gap-4">
-              <div class="w-14 h-14 bg-[#F1EFE9] border rounded overflow-hidden">
+            <div class="group relative flex items-center p-4 hover:bg-[#FDFBF9] transition-colors">
+              <div class="absolute left-0 top-0 w-1 h-full bg-[#365442] opacity-0 group-hover:opacity-40 transition-opacity"></div>
+              
+              <div class="w-14 h-14 bg-[#F1EFE9] border border-[#D6CEC5]/50 rounded-lg overflow-hidden flex-shrink-0">
                 <% if tea.image.attached? %>
-                  <%= image_tag tea.image, class: "w-full h-full object-cover" %>
+                  <%= image_tag tea.image, class: "w-full h-full object-cover group-hover:scale-105 transition-transform" %>
                 <% end %>
               </div>
-              <%= link_to tea.name, tea_product_path(tea),
-                  class: "font-bold text-[#365442] hover:text-[#A75F29]" %>
-            </li>
+              
+              <div class="ml-4 flex-grow">
+                <% if tea.brand.present? %>
+                  <p class="text-[11px] font-bold text-[#A75F29] uppercase tracking-tighter mt-0.5">
+                    <%= tea.brand.name_ja || tea.brand.name_en %>
+                  </p>
+                <% end %>
+                <%= link_to tea.name, tea_product_path(tea),
+                    class: "block font-bold text-[#365442] hover:text-[#A75F29] text-base leading-tight" %>
+              </div>
+              <div class="text-[#D6CEC5] group-hover:text-[#365442] transition-colors pr-2">
+                <span class="text-lg font-serif">→</span>
+              </div>
+            </div>
           <% end %>
-        </ul>
+        </div>
       <% else %>
-        <div class="text-center py-8 text-[#8C7B6C] text-sm">
-          まだお気に入り登録された紅茶はありません。<br>
-          紅茶一覧からお気に入りを見つけてみましょう。
-          <div class="mt-4">
-            <%= link_to "紅茶一覧を見る", tea_products_path,
-                class: "inline-block border border-[#365442] text-[#365442]
-                       px-4 py-2 rounded hover:bg-[#365442] hover:text-white
-                       transition text-xs font-bold" %>
-          </div>
+        <div class="p-10 text-center">
+          <p class="text-[#8C7B6C] text-sm font-medium italic mb-4">No favorites yet.</p>
+          <%= link_to "紅茶を探しに行く", tea_products_path,
+              class: "text-[11px] font-bold text-[#365442] border-b border-[#365442] pb-0.5 hover:text-[#A75F29] hover:border-[#A75F29] transition-colors" %>
         </div>
       <% end %>
     </div>
+
   </div>
 </div>


### PR DESCRIPTION
## 概要
マイページの自分の投稿一覧と、お気に入り一覧にページネーション追加、10件/ページで表示。
自分のレビュー一覧に合わせてデザインの方向性を統一、ブラッシュアップ。

## 対応issue
closed #162
 
## 目的
投稿数・お気に入り数が増加することによって、1画面に詰まりすぎる問題を解決するため。
UX改善で長時間スクロール不要にするため。
デザインの統一による世界観の維持。

## 実装内容
### 1. mypage/controller
ページネーションを追加。（該当コードのみ）
```
  def my_tea_products
    @posts = Kaminari.paginate_array(all_posts)
                     .page(params[:page])
                     .per(10)
  end

  def favorites
    @favorite_tea_products =.page(params[:page])
                            .per(10)
  end
  ```

### 2. ビュー
- `views/mypages/my_tea_products.html.erb`
```
<%= paginate @posts %>
```

- `views/mypages/favorites.html.erb`
```
<%= paginate @favorite_tea_products %>
```

### 3. デザイン
`app/views/mypages/show.html.erb`
`app/views/mypages/my_tea_products.html.erb`
`app/views/mypages/favorites.html.erb`


## 動作確認
- [ ] 自分の投稿一覧ページで投稿10件以上でページネーションが表示される
- [ ] お気に入り一覧ページで投稿10件以上でページネーションが表示される