### PR TITLE
feat: ページネーションにアプリデザイン適用

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,6 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.first?, "<<", url, remote: remote,
+      class: "flex items-center justify-center min-w-[60px] h-[42px] px-3 bg-[#EBE5DE] border-2 border-[#D6CEC5] text-[#A75F29] rounded-xl font-bold text-[13px] tracking-tighter hover:border-[#A75F29] hover:text-[#A75F29] transition-all shadow-sm no-underline" %>
 </span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="flex items-center justify-center min-w-[42px] h-[42px] text-[#B5A89A] cursor-default">
+  <%= t('views.pagination.truncate').html_safe %>
+</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,6 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.last?, ">>", url, remote: remote,
+      class: "flex items-center justify-center min-w-[60px] h-[42px] px-3 bg-[#EBE5DE] border-2 border-[#D6CEC5] text-[#A75F29] rounded-xl font-bold text-[13px] tracking-tighter hover:border-[#A75F29] hover:text-[#A75F29] transition-all shadow-sm no-underline" %>
 </span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,4 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: "px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition" %>
+<%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote,
+    class: "flex items-center justify-center min-w-[42px] h-[42px] px-3 bg-white border-2 border-[#D6CEC5] text-[#365442] rounded-xl font-bold text-[13px] uppercase tracking-tighter hover:border-[#A75F29] hover:text-[#A75F29] transition-all shadow-sm no-underline" %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,9 +8,10 @@
     remote:        data-remote
 -%>
 <% if page.current? %>
-  <span class="px-4 py-2 bg-blue-500 text-white rounded-md font-semibold">
+  <span class="flex items-center justify-center min-w-[42px] h-[42px] px-3 bg-[#365442] border-2 border-[#365442] text-white rounded-xl font-bold shadow-inner cursor-default">
     <%= page %>
   </span>
 <% else %>
-  <%= link_to page, url, class: "px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition", remote: remote %>
+  <%= link_to page, url, remote: remote,
+      class: "flex items-center justify-center min-w-[42px] h-[42px] px-3 bg-white border-2 border-[#D6CEC5] text-[#365442] rounded-xl font-bold hover:border-[#A75F29] hover:text-[#A75F29] hover:-translate-y-0.5 transition-all duration-200 no-underline shadow-sm" %>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,4 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: "px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition" %>
+<%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote,
+    class: "flex items-center justify-center min-w-[42px] h-[42px] px-3 bg-white border-2 border-[#D6CEC5] text-[#365442] rounded-xl font-bold text-[13px] uppercase tracking-tighter hover:border-[#A75F29] hover:text-[#A75F29] transition-all shadow-sm no-underline" %>


### PR DESCRIPTION
## 概要
アプリ内のページネーション部分を、デフォルトデザインからアプリの世界観に合うように編集

## 目的
アプリの世界観の統一。
UX、UIの向上。

## 実装内容
#### app/views/kaminari/を編集。
`_first_page.html.erb`
`_last_page.html.erb`
`_next_page.html.erb`
`_prev_page.html.erb`
`_page.html.erb`
`_gap.html.erb`

## 動作確認
- [x] ページネーションが正しく表示される。
- [x] 最初、最後、次へ、前へボタンの動作に齟齬がない。